### PR TITLE
Refresh contact list on decrypt

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,9 @@
       document.getElementById('imageGroup').classList.toggle('hidden', action !== 'encryptImage');
       document.getElementById('qrGroup').classList.toggle('hidden', action !== 'decryptQR');
       document.getElementById('pubKeyGroup').classList.toggle('hidden', !(action.startsWith('decrypt')));
+      if (action.startsWith('decrypt')) {
+        updateContactDropdown();
+      }
 
       // Toggle buttons based on action for UI clarity:
       if (action === 'encryptImage') {


### PR DESCRIPTION
## Summary
- Repopulate and reveal saved contacts when switching to decrypt actions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a10bd4d008331bb244ddacfaa1653