### PR TITLE
Refresh contacts when switching to decrypt

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,12 +298,13 @@
     
     function adjustView() {
       const action = document.getElementById('action').value;
-      document.getElementById('messageGroup').classList.toggle('hidden', action !== 'encryptText' && action !== 'decrypt');
+      const isDecrypt = action.startsWith('decrypt');
+      document.getElementById('messageGroup').classList.toggle('hidden', action !== 'encryptText' && !isDecrypt);
       document.getElementById('textFileGroup').classList.toggle('hidden', action !== 'decryptFile');
       document.getElementById('imageGroup').classList.toggle('hidden', action !== 'encryptImage');
       document.getElementById('qrGroup').classList.toggle('hidden', action !== 'decryptQR');
-      document.getElementById('pubKeyGroup').classList.toggle('hidden', !(action.startsWith('decrypt')));
-      if (action.startsWith('decrypt')) {
+      document.getElementById('pubKeyGroup').classList.toggle('hidden', !isDecrypt);
+      if (isDecrypt) {
         updateContactDropdown();
       }
 


### PR DESCRIPTION
## Summary
- Recompute view state with an `isDecrypt` flag
- Repopulate saved contacts whenever decrypt is selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a166baa54833189ca23f2bb32f498