### PR TITLE
Add experimental ratchet session helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No logs. No identities. No dependencies.
 - Share encrypted messages via URL hash fragments (with auto-decrypt preload and reduced referer leakage)
 - Sign and verify messages with ECDSA digital signatures
 - Generate and export ECDSA key pairs for signing and verification
+- Experimental `RatchetSession` for ephemeral ECDH exchange with per-message HKDF key ratchet
 - Public key address book to save and reuse sender keys with custom names and images
 - **Reset** button to clear fields and state
 - Copy-to-clipboard functionality
@@ -69,12 +70,16 @@ No logs. No identities. No dependencies.
 When encrypting text or files, you can generate a shareable link that stores data
 in the URL hash fragment. Anyone with this link and the correct passphrase can decrypt the message, and using the hash helps prevent leakage via HTTP Referer headers.
 
+## 🔄 Ephemeral Sessions (Experimental)
+
+`ratchet.js` contains a small `RatchetSession` helper showing how two parties can exchange an ephemeral ECDH key pair and then derive a fresh symmetric key for every message via HKDF. This provides lightweight forward secrecy without repeating the key exchange.
+
 ## ⚠️ Security & Connectivity Notes
 
 - All encryption is performed **client-side** — your passphrase is never stored or transmitted.
 - **Offline Functionality:** Although the encryption operations run entirely offline once the app is loaded, an internet connection is required for the initial loading of external JavaScript libraries. A future release will host these libraries locally, eliminating this dependency.
 - Choose a strong, unique passphrase to maximize security.
-- The app provides optional digital signatures for authenticity but **does not support forward secrecy**.
+- The primary interface uses passphrases and does not provide forward secrecy; the optional ratchet helper adds it per message.
 - Designed for **anonymity and plausible deniability**, not for audit logs or compliance.
 
 ## 🧪 Use Cases

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
   <script src="https://cdn.jsdelivr.net/npm/zxcvbn@4.4.2/dist/zxcvbn.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.4.4/build/qrcode.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js" defer></script>
+  <script src="ratchet.js" defer></script>
   <style>
     body {
       font-family: Arial, sans-serif;

--- a/ratchet.js
+++ b/ratchet.js
@@ -1,0 +1,114 @@
+// Simple RatchetSession implementation using WebCrypto
+// Generates an ephemeral ECDH key pair and derives new symmetric keys per message
+
+const _enc = new TextEncoder();
+const _dec = new TextDecoder();
+
+function _bufToB64(buf) {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)));
+}
+
+function _b64ToBuf(b64) {
+  return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+}
+
+async function _hkdf(keyMaterial, info) {
+  const salt = new Uint8Array(32); // all zeros
+  const key = await crypto.subtle.importKey('raw', keyMaterial, 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.subtle.deriveBits({
+    name: 'HKDF',
+    hash: 'SHA-256',
+    salt,
+    info: _enc.encode(info)
+  }, key, 256);
+  return new Uint8Array(bits);
+}
+
+class RatchetSession {
+  constructor() {
+    this.keyPair = null;
+    this.publicKey = null;
+    this.sendChainKey = null;
+    this.recvChainKey = null;
+  }
+
+  // Create a new session with fresh ECDH key pair
+  static async create() {
+    const s = new RatchetSession();
+    s.keyPair = await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' },
+      true,
+      ['deriveBits']
+    );
+    s.publicKey = await s.exportPublicKey();
+    return s;
+  }
+
+  // Export public key as base64 string
+  async exportPublicKey() {
+    const raw = await crypto.subtle.exportKey('raw', this.keyPair.publicKey);
+    return _bufToB64(raw);
+  }
+
+  // Import peer public key from base64
+  async importPeerPublicKey(b64) {
+    const raw = _b64ToBuf(b64);
+    return crypto.subtle.importKey(
+      'raw',
+      raw,
+      { name: 'ECDH', namedCurve: 'P-256' },
+      true,
+      []
+    );
+  }
+
+  // After exchanging public keys, derive shared secret and set chain keys.
+  // Initiator and responder swap send/receive derivations.
+  async init(peerPublicB64, initiator = true) {
+    const peerKey = await this.importPeerPublicKey(peerPublicB64);
+    const shared = await crypto.subtle.deriveBits({ name: 'ECDH', public: peerKey }, this.keyPair.privateKey, 256);
+    const rootKey = new Uint8Array(shared);
+    if (initiator) {
+      this.sendChainKey = await _hkdf(rootKey, 'init_send');
+      this.recvChainKey = await _hkdf(rootKey, 'init_recv');
+    } else {
+      this.sendChainKey = await _hkdf(rootKey, 'init_recv');
+      this.recvChainKey = await _hkdf(rootKey, 'init_send');
+    }
+  }
+
+  async _nextSendKey() {
+    const mk = await _hkdf(this.sendChainKey, 'msg');
+    this.sendChainKey = await _hkdf(this.sendChainKey, 'chain');
+    return mk;
+  }
+
+  async _nextRecvKey() {
+    const mk = await _hkdf(this.recvChainKey, 'msg');
+    this.recvChainKey = await _hkdf(this.recvChainKey, 'chain');
+    return mk;
+  }
+
+  // Encrypt a UTF-8 string, returning base64 iv and ciphertext
+  async encrypt(plaintext) {
+    const keyBytes = await this._nextSendKey();
+    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, _enc.encode(plaintext));
+    return { iv: _bufToB64(iv), data: _bufToB64(cipher) };
+  }
+
+  // Decrypt using current receiving chain key
+  async decrypt(bundle) {
+    const keyBytes = await this._nextRecvKey();
+    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
+    const iv = _b64ToBuf(bundle.iv);
+    const data = _b64ToBuf(bundle.data);
+    const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+    return _dec.decode(plain);
+  }
+}
+
+// Expose globally
+window.RatchetSession = RatchetSession;
+


### PR DESCRIPTION
## Summary
- expose `RatchetSession` helper for ephemeral ECDH handshake and HKDF key ratchet
- load helper from `index.html`
- document new feature in README

## Testing
- `npm test` *(fails: package.json not found)*


------
https://chatgpt.com/codex/tasks/task_e_689a372d8a308331b1f5b46551981e12