### PR TITLE
Default to ratchet-based forward secrecy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beam
 
-**Beam** is a lightweight, offline encryption tool built for **privacy, simplicity, and control**. Designed as a standalone Progressive Web App (PWA), it enables peer-to-peer message and file encryption using high-entropy passphrases — with **no servers**, **no accounts**, and **no data collection**. Once loaded, Beam works entirely offline.
+**Beam** is a lightweight, offline encryption tool built for **privacy, simplicity, and control**. Designed as a standalone Progressive Web App (PWA), it enables peer-to-peer message and file encryption with per-session forward secrecy — with **no servers**, **no accounts**, and **no data collection**. Once loaded, Beam works entirely offline.
 
 ## 🛡️ Privacy-First Philosophy
 
@@ -16,8 +16,7 @@ No logs. No identities. No dependencies.
 ## ✨ Features
 
 - **AES-256-GCM** encryption via the WebCrypto API
-- **PBKDF2** key derivation (150k iterations, SHA-256)
-- Custom passphrase input with a strength meter powered by **zxcvbn** (score ≥3 enforced)
+- Ephemeral ECDH session with per-message HKDF ratchet providing forward secrecy
 - Encrypt and decrypt text, images, and encrypted text files
 - **Image Encryption** with MIME type preservation and auto-download of decrypted files
   _Note: Only images up to 100kb are supported. Larger images will trigger an error message._
@@ -33,25 +32,19 @@ No logs. No identities. No dependencies.
 - Mobile-first responsive layout
 - Fully offline, installable PWA experience on Android and desktop
 
-## 🔐 Passphrase Guidelines
-
-- Passphrases must be at least 6 characters long.
-- The app enforces a minimum zxcvbn strength score of **3** before enabling any actions.
-- Choose a strong, unique passphrase to maximize security.
-
 ## 🚀 How to Use
 
 1. Open `index.html` in a browser (mobile or desktop).
 2. *(Optional)* Click **Generate Key Pair** to create an ECDSA key pair for signing. Use **Export Public Key** to share your public key with others.
-3. Select one of the actions from the dropdown:
+3. Share your session key with your peer and paste theirs to initialize the ratchet.
+4. Select one of the actions from the dropdown:
    - **Encrypt Text**
    - **Decrypt Text**
    - **Decrypt Text File**
    - **Encrypt Image**
    - **Decrypt QR**
 4. For encryption, enter your message or upload an image (ensure the image is **100kb or smaller**); for decryption, paste the encrypted string, upload an encrypted text file, or scan/upload a QR code image.
-5. Enter your passphrase.
-6. Click the corresponding action button:
+5. Click the corresponding action button:
    - **Run** for text encryption/decryption
    - **Encrypt Image** for image encryption
    - **Decode QR** for QR code decryption
@@ -67,14 +60,17 @@ No logs. No identities. No dependencies.
 ## 🔗 URL-Based Sharing
 
 When encrypting text or files, you can generate a shareable link that stores data
-in the URL hash fragment. Anyone with this link and the correct passphrase can decrypt the message, and using the hash helps prevent leakage via HTTP Referer headers.
+in the URL hash fragment. Anyone with this link and the session state can decrypt the message, and using the hash helps prevent leakage via HTTP Referer headers.
+
+## 🔄 Ephemeral Sessions
+
+`ratchet.js` powers the default `RatchetSession` implementation used throughout the app. Two parties exchange an ephemeral ECDH key pair and then derive a fresh symmetric key for every message via HKDF, providing lightweight forward secrecy without repeating the key exchange.
 
 ## ⚠️ Security & Connectivity Notes
 
-- All encryption is performed **client-side** — your passphrase is never stored or transmitted.
+- All encryption is performed **client-side** — session secrets are never stored or transmitted.
 - **Offline Functionality:** Although the encryption operations run entirely offline once the app is loaded, an internet connection is required for the initial loading of external JavaScript libraries. A future release will host these libraries locally, eliminating this dependency.
-- Choose a strong, unique passphrase to maximize security.
-- The app provides optional digital signatures for authenticity but **does not support forward secrecy**.
+- Designed for forward secrecy by default using an ephemeral ratchet session.
 - Designed for **anonymity and plausible deniability**, not for audit logs or compliance.
 
 ## 🧪 Use Cases

--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
     }
   </script>
   <!-- Updated external library references -->
-  <script src="https://cdn.jsdelivr.net/npm/zxcvbn@4.4.2/dist/zxcvbn.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.4.4/build/qrcode.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js" defer></script>
+  <script src="ratchet.js" defer></script>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -76,10 +76,6 @@
       background: #0056b3;
     }
     .hidden { display: none; }
-    #strength {
-      font-size: 0.9rem;
-      margin-top: 0.25rem;
-    }
     .tools {
       display: flex;
       flex-direction: column;
@@ -138,10 +134,13 @@
       <input type="file" id="qrInput" accept="image/*">
     </div>
     
-    <label for="key">Passphrase:</label>
-    <input type="password" id="key" oninput="checkStrength()" placeholder="Enter your passphrase">
-    <button onclick="togglePasswordVisibility()">Toggle Visibility</button>
-    <div id="strength"></div>
+    <div id="sessionGroup">
+      <label>Your Session Key (share with peer):</label>
+      <textarea id="mySessionKey" rows="2" readonly></textarea>
+      <label for="peerSessionKey">Peer Session Key:</label>
+      <textarea id="peerSessionKey" rows="2" placeholder="Paste peer session key..."></textarea>
+      <button type="button" id="initSession">Initialize Session</button>
+    </div>
 
     <div id="pubKeyGroup" class="hidden">
       <label for="senderPubKey">Sender Public Key:</label>
@@ -163,9 +162,9 @@
     </div>
 
     <div class="tools" style="margin-top: 10px;">
-      <button id="runButton" disabled>Run</button>
-      <button id="encryptImage" disabled>Encrypt Image</button>
-      <button id="decodeQR" disabled>Decode QR</button>
+      <button id="runButton">Run</button>
+      <button id="encryptImage">Encrypt Image</button>
+      <button id="decodeQR">Decode QR</button>
       <button onclick="resetForm()">Reset</button>
       <button onclick="copyToClipboard()">Copy Result</button>
       <button id="generateKeys">Generate Key Pair</button>
@@ -328,20 +327,9 @@
       }
     }
     
-    function togglePasswordVisibility() { 
-      const keyInput = document.getElementById('key'); 
-      keyInput.type = keyInput.type === 'password' ? 'text' : 'password'; 
-    }
-    
-    function checkStrength() {
-      const input = document.getElementById('key').value;
-      const result = zxcvbn(input);
-      const levels = ['Very Weak', 'Weak', 'Fair', 'Good', 'Strong'];
-      document.getElementById('strength').textContent = 'Strength: ' + levels[result.score];
-      const strong = result.score >= 3;
-      document.getElementById('runButton').disabled = !strong;
-      document.getElementById('encryptImage').disabled = !strong;
-      document.getElementById('decodeQR').disabled = !strong;
+    async function setupSession() {
+      window.session = await RatchetSession.create();
+      document.getElementById('mySessionKey').value = session.publicKey;
     }
     
     function copyToClipboard() { 
@@ -357,10 +345,9 @@
       document.getElementById('fileInput').value = '';
       document.getElementById('imageInput').value = '';
       document.getElementById('qrInput').value = '';
-      document.getElementById('key').value = '';
+      document.getElementById('peerSessionKey').value = '';
       document.getElementById('senderPubKey').value = '';
       document.getElementById('result').textContent = '';
-      document.getElementById('strength').textContent = '';
       document.getElementById('qrcode').innerHTML = '';
       const select = document.getElementById('contactSelect');
       if (select) select.selectedIndex = 0;
@@ -370,7 +357,7 @@
       if (editBtn) editBtn.classList.add('hidden');
       const delBtn = document.getElementById('deleteContactBtn');
       if (delBtn) delBtn.classList.add('hidden');
-      checkStrength();
+      setupSession();
     }
 
     let contacts = [];
@@ -406,7 +393,13 @@
     
     document.addEventListener('DOMContentLoaded', () => {
       adjustView();
-      checkStrength();
+      setupSession();
+      document.getElementById('initSession').addEventListener('click', async () => {
+        const peer = document.getElementById('peerSessionKey').value.trim();
+        if (!peer) return alert('Enter peer session key.');
+        await session.init(peer, true);
+        alert('Session initialized!');
+      });
 
       contacts = JSON.parse(localStorage.getItem('contacts') || '[]');
       updateContactDropdown();
@@ -508,37 +501,20 @@
         adjustView();
       }
     
-      document.getElementById('runButton').addEventListener('click', async () => { 
+      document.getElementById('runButton').addEventListener('click', async () => {
         const action = document.getElementById('action').value;
-        const passphrase = document.getElementById('key').value.trim();
         const resultDiv = document.getElementById('result');
         const qrCodeDiv = document.getElementById('qrcode');
         qrCodeDiv.innerHTML = '';
-        if (passphrase.length < 6) return alert('Passphrase must be at least 6 characters.');
-        if (zxcvbn(passphrase).score < 3) return alert('Passphrase is too weak.');
+        if (!window.session || !session.sendChainKey) return alert('Initialize the session first.');
     
         try {
           if (action === 'encryptText') {
-            const message = document.getElementById('message').value; 
-            const salt = crypto.getRandomValues(new Uint8Array(16));
-            const iv = crypto.getRandomValues(new Uint8Array(12));
-            const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-            const key = await crypto.subtle.deriveKey(
-              { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-              keyMaterial,
-              { name: "AES-GCM", length: 256 },
-              false,
-              ["encrypt", "decrypt"]
-            );
-            const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, enc.encode(message));
-            const ctArray = new Uint8Array(ciphertext);
-            const combined = new Uint8Array(salt.length + iv.length + ctArray.length);
-            combined.set(salt, 0);
-            combined.set(iv, salt.length);
-            combined.set(ctArray, salt.length + iv.length);
-            const output = bytesToBase64(combined);
-            const signature = await signData(output);
-            const signedOutput = signature + '.' + output;
+            const message = document.getElementById('message').value;
+            const bundle = await session.encrypt(message);
+            const payload = btoa(JSON.stringify(bundle));
+            const signature = await signData(payload);
+            const signedOutput = signature + '.' + payload;
 
             if (signedOutput.length > MAX_OUTPUT_LENGTH) {
               resultDiv.textContent = `Encrypted Code (too long for QR):\n\n${signedOutput}\n\nDownloading as text file...`;
@@ -561,27 +537,16 @@
             }
           } else if (action === 'decrypt') {
             const message = document.getElementById('message').value;
-            const [sigB64, cipherB64] = message.split('.', 2);
-            if (!sigB64 || !cipherB64) throw new Error('Invalid signed message format.');
+            const [sigB64, payloadB64] = message.split('.', 2);
+            if (!sigB64 || !payloadB64) throw new Error('Invalid signed message format.');
             const pubText = document.getElementById('senderPubKey').value.trim();
-            const valid = await verifyData(cipherB64, sigB64, pubText);
-            const data = Uint8Array.from(atob(cipherB64), c => c.charCodeAt(0));
-            const salt = data.slice(0, 16);
-            const iv = data.slice(16, 28);
-            const ciphertext = data.slice(28);
-            const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-            const key = await crypto.subtle.deriveKey(
-              { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-              keyMaterial,
-              { name: "AES-GCM", length: 256 },
-              false,
-              ["decrypt"]
-            );
-            const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
-            const sepIndex = new Uint8Array(decrypted).indexOf(124);
+            const valid = await verifyData(payloadB64, sigB64, pubText);
+            const bundle = JSON.parse(atob(payloadB64));
+            const decrypted = await session.decrypt(bundle);
+            const sepIndex = decrypted.indexOf('|');
             if (sepIndex !== -1) {
-              const mime = new TextDecoder().decode(new Uint8Array(decrypted).slice(0, sepIndex));
-              const content = new Uint8Array(decrypted).slice(sepIndex + 1);
+              const mime = decrypted.slice(0, sepIndex);
+              const content = Uint8Array.from(atob(decrypted.slice(sepIndex + 1)), c => c.charCodeAt(0));
               const blob = new Blob([content], { type: mime });
               const link = document.createElement('a');
               link.href = URL.createObjectURL(blob);
@@ -589,7 +554,7 @@
               link.click();
               resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\nDecrypted File (${mime}) downloaded.`;
             } else {
-              resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\n\nDecrypted Message:\n\n${new TextDecoder().decode(decrypted)}`;
+              resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\n\nDecrypted Message:\n\n${decrypted}`;
             }
           } else if (action === 'decryptFile') {
             const fileInput = document.getElementById('fileInput');
@@ -597,27 +562,16 @@
             const reader = new FileReader();
             reader.onload = async function () {
               const fileContent = reader.result.trim();
-              const [sigB64, cipherB64] = fileContent.split('.', 2);
+              const [sigB64, payloadB64] = fileContent.split('.', 2);
               try {
                 const pubText = document.getElementById('senderPubKey').value.trim();
-                const valid = await verifyData(cipherB64, sigB64, pubText);
-                const data = Uint8Array.from(atob(cipherB64), c => c.charCodeAt(0));
-                const salt = data.slice(0, 16);
-                const iv = data.slice(16, 28);
-                const ciphertext = data.slice(28);
-                const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-                const key = await crypto.subtle.deriveKey(
-                  { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-                  keyMaterial,
-                  { name: "AES-GCM", length: 256 },
-                  false,
-                  ["decrypt"]
-                );
-                const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
-                const sepIndex = new Uint8Array(decrypted).indexOf(124);
+                const valid = await verifyData(payloadB64, sigB64, pubText);
+                const bundle = JSON.parse(atob(payloadB64));
+                const decrypted = await session.decrypt(bundle);
+                const sepIndex = decrypted.indexOf('|');
                 if (sepIndex !== -1) {
-                  const mime = new TextDecoder().decode(new Uint8Array(decrypted).slice(0, sepIndex));
-                  const content = new Uint8Array(decrypted).slice(sepIndex + 1);
+                  const mime = decrypted.slice(0, sepIndex);
+                  const content = Uint8Array.from(atob(decrypted.slice(sepIndex + 1)), c => c.charCodeAt(0));
                   const blob = new Blob([content], { type: mime });
                   const link = document.createElement('a');
                   link.href = URL.createObjectURL(blob);
@@ -625,7 +579,7 @@
                   link.click();
                   resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\nDecrypted File (${mime}) downloaded.`;
                 } else {
-                  resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\n\nDecrypted Message:\n\n${new TextDecoder().decode(decrypted)}`;
+                  resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\n\nDecrypted Message:\n\n${decrypted}`;
                 }
               } catch (err) {
                 resultDiv.textContent = 'Error: ' + err.message;
@@ -643,7 +597,6 @@
     const fileInput = document.getElementById('imageInput');
     const resultDiv = document.getElementById('result');
     const qrCodeDiv = document.getElementById('qrcode');
-    const passphrase = document.getElementById('key').value.trim();
     if (!fileInput.files[0]) return alert('Please upload an image.');
 
     // Check if the image file size exceeds 100kb (100 * 1024 bytes)
@@ -652,9 +605,8 @@
       return;
     }
 
-    if (passphrase.length < 6) return alert('Passphrase must be at least 6 characters.');
-    if (zxcvbn(passphrase).score < 3) return alert('Passphrase is too weak.');
-    
+    if (!window.session || !session.sendChainKey) return alert('Initialize the session first.');
+
     const reader = new FileReader();
     reader.onload = async function () {
       const arrayBuffer = reader.result;
@@ -663,26 +615,11 @@
       const fullBuffer = new Uint8Array(prefix.length + arrayBuffer.byteLength);
       fullBuffer.set(prefix, 0);
       fullBuffer.set(new Uint8Array(arrayBuffer), prefix.length);
-      
-      const salt = crypto.getRandomValues(new Uint8Array(16));
-      const iv = crypto.getRandomValues(new Uint8Array(12));
-      const keyMaterial = await crypto.subtle.importKey("raw", new TextEncoder().encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-      const key = await crypto.subtle.deriveKey(
-        { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-        keyMaterial,
-        { name: "AES-GCM", length: 256 },
-        false,
-        ["encrypt"]
-      );
-      const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, fullBuffer);
-      const ctArray = new Uint8Array(ciphertext);
-      const combined = new Uint8Array(salt.length + iv.length + ctArray.length);
-      combined.set(salt, 0);
-      combined.set(iv, salt.length);
-      combined.set(ctArray, salt.length + iv.length);
-      const output = bytesToBase64(combined);
-      const signature = await signData(output);
-      const signedOutput = signature + '.' + output;
+
+      const bundle = await session.encrypt(bytesToBase64(fullBuffer));
+      const payload = btoa(JSON.stringify(bundle));
+      const signature = await signData(payload);
+      const signedOutput = signature + '.' + payload;
 
       if (signedOutput.length > 1000) {
         resultDiv.textContent = `Encrypted Code (too long for QR):\n\n${signedOutput}\n\nDownloading as text file...`;
@@ -709,14 +646,12 @@
   });
     
       // Decode QR button handler
-      document.getElementById('decodeQR').addEventListener('click', async () => { 
+      document.getElementById('decodeQR').addEventListener('click', async () => {
         const fileInput = document.getElementById('qrInput');
-        const passphrase = document.getElementById('key').value.trim();
         const resultDiv = document.getElementById('result');
         if (!fileInput.files[0]) return alert('Please upload a QR code image.');
-        if (passphrase.length < 6) return alert('Passphrase must be at least 6 characters.');
-        if (zxcvbn(passphrase).score < 3) return alert('Passphrase is too weak.');
-    
+        if (!window.session || !session.sendChainKey) return alert('Initialize the session first.');
+
         const reader = new FileReader();
         reader.onload = async function () {
           const img = new Image();
@@ -729,29 +664,18 @@
             const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
             const code = jsQR(imageData.data, canvas.width, canvas.height);
             if (!code) return alert('QR code could not be read.');
-    
+
             try {
-              const [sigB64, cipherB64] = code.data.split('.', 2);
-              if (!sigB64 || !cipherB64) throw new Error('Invalid signed message format.');
+              const [sigB64, payloadB64] = code.data.split('.', 2);
+              if (!sigB64 || !payloadB64) throw new Error('Invalid signed message format.');
               const pubText = document.getElementById('senderPubKey').value.trim();
-              const valid = await verifyData(cipherB64, sigB64, pubText);
-              const data = Uint8Array.from(atob(cipherB64), c => c.charCodeAt(0));
-              const salt = data.slice(0, 16);
-              const iv = data.slice(16, 28);
-              const ciphertext = data.slice(28);
-              const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-              const key = await crypto.subtle.deriveKey(
-                { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-                keyMaterial,
-                { name: "AES-GCM", length: 256 },
-                false,
-                ["decrypt"]
-              );
-              const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
-              const sepIndex = new Uint8Array(decrypted).indexOf(124);
+              const valid = await verifyData(payloadB64, sigB64, pubText);
+              const bundle = JSON.parse(atob(payloadB64));
+              const decrypted = await session.decrypt(bundle);
+              const sepIndex = decrypted.indexOf('|');
               if (sepIndex !== -1) {
-                const mime = new TextDecoder().decode(new Uint8Array(decrypted).slice(0, sepIndex));
-                const content = new Uint8Array(decrypted).slice(sepIndex + 1);
+                const mime = decrypted.slice(0, sepIndex);
+                const content = Uint8Array.from(atob(decrypted.slice(sepIndex + 1)), c => c.charCodeAt(0));
                 const blob = new Blob([content], { type: mime });
                 const link = document.createElement('a');
                 link.href = URL.createObjectURL(blob);
@@ -759,7 +683,7 @@
                 link.click();
                 resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\nDecrypted File (${mime}) downloaded.`;
               } else {
-                resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\n\nDecrypted Message:\n\n${new TextDecoder().decode(decrypted)}`;
+                resultDiv.textContent = `Signature ${valid ? 'Valid' : 'Invalid'}\n\nDecrypted Message:\n\n${decrypted}`;
               }
             } catch (err) {
               resultDiv.textContent = 'Error: ' + err.message;

--- a/ratchet.js
+++ b/ratchet.js
@@ -1,0 +1,114 @@
+// Simple RatchetSession implementation using WebCrypto
+// Generates an ephemeral ECDH key pair and derives new symmetric keys per message
+
+const _enc = new TextEncoder();
+const _dec = new TextDecoder();
+
+function _bufToB64(buf) {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)));
+}
+
+function _b64ToBuf(b64) {
+  return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+}
+
+async function _hkdf(keyMaterial, info) {
+  const salt = new Uint8Array(32); // all zeros
+  const key = await crypto.subtle.importKey('raw', keyMaterial, 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.subtle.deriveBits({
+    name: 'HKDF',
+    hash: 'SHA-256',
+    salt,
+    info: _enc.encode(info)
+  }, key, 256);
+  return new Uint8Array(bits);
+}
+
+class RatchetSession {
+  constructor() {
+    this.keyPair = null;
+    this.publicKey = null;
+    this.sendChainKey = null;
+    this.recvChainKey = null;
+  }
+
+  // Create a new session with fresh ECDH key pair
+  static async create() {
+    const s = new RatchetSession();
+    s.keyPair = await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' },
+      true,
+      ['deriveBits']
+    );
+    s.publicKey = await s.exportPublicKey();
+    return s;
+  }
+
+  // Export public key as base64 string
+  async exportPublicKey() {
+    const raw = await crypto.subtle.exportKey('raw', this.keyPair.publicKey);
+    return _bufToB64(raw);
+  }
+
+  // Import peer public key from base64
+  async importPeerPublicKey(b64) {
+    const raw = _b64ToBuf(b64);
+    return crypto.subtle.importKey(
+      'raw',
+      raw,
+      { name: 'ECDH', namedCurve: 'P-256' },
+      true,
+      []
+    );
+  }
+
+  // After exchanging public keys, derive shared secret and set chain keys.
+  // Initiator and responder swap send/receive derivations.
+  async init(peerPublicB64, initiator = true) {
+    const peerKey = await this.importPeerPublicKey(peerPublicB64);
+    const shared = await crypto.subtle.deriveBits({ name: 'ECDH', public: peerKey }, this.keyPair.privateKey, 256);
+    const rootKey = new Uint8Array(shared);
+    if (initiator) {
+      this.sendChainKey = await _hkdf(rootKey, 'init_send');
+      this.recvChainKey = await _hkdf(rootKey, 'init_recv');
+    } else {
+      this.sendChainKey = await _hkdf(rootKey, 'init_recv');
+      this.recvChainKey = await _hkdf(rootKey, 'init_send');
+    }
+  }
+
+  async _nextSendKey() {
+    const mk = await _hkdf(this.sendChainKey, 'msg');
+    this.sendChainKey = await _hkdf(this.sendChainKey, 'chain');
+    return mk;
+  }
+
+  async _nextRecvKey() {
+    const mk = await _hkdf(this.recvChainKey, 'msg');
+    this.recvChainKey = await _hkdf(this.recvChainKey, 'chain');
+    return mk;
+  }
+
+  // Encrypt a UTF-8 string, returning base64 iv and ciphertext
+  async encrypt(plaintext) {
+    const keyBytes = await this._nextSendKey();
+    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, _enc.encode(plaintext));
+    return { iv: _bufToB64(iv), data: _bufToB64(cipher) };
+  }
+
+  // Decrypt using current receiving chain key
+  async decrypt(bundle) {
+    const keyBytes = await this._nextRecvKey();
+    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
+    const iv = _b64ToBuf(bundle.iv);
+    const data = _b64ToBuf(bundle.data);
+    const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+    return _dec.decode(plain);
+  }
+}
+
+// Expose globally
+window.RatchetSession = RatchetSession;
+


### PR DESCRIPTION
## Summary
- replace passphrase-based workflow with RatchetSession key ratchet
- add session key exchange controls to the UI
- document default forward secrecy in README

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a372d8a308331b1f5b46551981e12