### PR TITLE
Fix step numbering in README How to Use section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ No logs. No identities. No dependencies.
    - **Decrypt Text File**
    - **Encrypt Image**
    - **Decrypt QR**
-4. For encryption, enter your message or upload an image (ensure the image is **100kb or smaller**); for decryption, paste the encrypted string, upload an encrypted text file, or scan/upload a QR code image.
-5. Click the corresponding action button:
+5. For encryption, enter your message or upload an image (ensure the image is **100kb or smaller**); for decryption, paste the encrypted string, upload an encrypted text file, or scan/upload a QR code image.
+6. Click the corresponding action button:
    - **Run** for text encryption/decryption
    - **Encrypt Image** for image encryption
    - **Decode QR** for QR code decryption


### PR DESCRIPTION
## Summary
- fix duplicate numbering and sequential steps in "How to Use" section of README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a52bfae188331a57b4b9e682a1535