### PR TITLE
docs: update security notes for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Beam uses `ratchet.js` as its default `RatchetSession` implementation. Two parti
 ## ⚠️ Security & Connectivity Notes
 
 - All encryption is performed **client-side** — session secrets are never stored or transmitted.
-- **Offline Functionality:** Although the encryption operations run entirely offline once the app is loaded, an internet connection is required for the initial loading of external JavaScript libraries. A future release will host these libraries locally, eliminating this dependency.
+- **Offline Functionality:** All required libraries (`qrcode.min.js`, `jsQR.js`, `ratchet.js`) are bundled locally, so Beam runs fully offline once the page is loaded.
 - Designed for forward secrecy by default using an ephemeral ratchet session.
 - Designed for **anonymity and plausible deniability**, not for audit logs or compliance.
 


### PR DESCRIPTION
## Summary
- clarify that Beam bundles qrcode.min.js, jsQR.js, and ratchet.js locally
- remove outdated statement about needing the internet for external scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a55c9e6b0833180148691c4b96e84