### PR TITLE
feat: add identity keys and signed prekeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No logs. No identities. No dependencies.
 - Sign and verify messages with ECDSA digital signatures
 - Generate and export ECDSA key pairs for signing and verification
 - `RatchetSession` for ephemeral ECDH exchange with per-message HKDF key ratchet
+- Persistent identity key pair stored in local storage with signed prekeys for peer verification (X3DH-style)
 - Public key address book to save and reuse sender keys with custom names and images
 - **Reset** button to clear fields and state
 - Copy-to-clipboard functionality


### PR DESCRIPTION
## Summary
- persist a long-term identity key pair in local storage
- sign and export prekeys so peers can verify each other before starting a session
- document identity key usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a58b72dc08331bf71c7db80b67154