### PR TITLE
feat: implement double ratchet with header auth

### DIFF
--- a/libs/ratchet.js
+++ b/libs/ratchet.js
@@ -1,5 +1,5 @@
-// Simple RatchetSession implementation using WebCrypto
-// Generates an ephemeral ECDH key pair and derives new symmetric keys per message
+// Double Ratchet implementation using WebCrypto
+// Adds per-message DH ratchets, header authentication and skipped-key queue
 
 const _enc = new TextEncoder();
 const _dec = new TextDecoder();
@@ -24,38 +24,60 @@ async function _hkdf(keyMaterial, info) {
   return new Uint8Array(bits);
 }
 
+async function _hmacSign(keyBytes, data) {
+  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  return new Uint8Array(await crypto.subtle.sign('HMAC', key, data));
+}
+
+async function _hmacVerify(keyBytes, data, sig) {
+  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+  return crypto.subtle.verify('HMAC', key, sig, data);
+}
+
 class RatchetSession {
   constructor() {
     this.identityKeyPair = null; // persistent signing key
-    this.keyPair = null; // ECDH ratchet key pair
-    this.publicKey = null;
+    this.DHs = null; // our current ECDH ratchet key pair
+    this.DHr = null; // their current ECDH public key
+    this.publicKey = null; // cached base64 of DHs public key
     this.signedPrekey = null; // { key: b64, sig: b64 }
-    this.sendChainKey = null;
-    this.recvChainKey = null;
+
+    // Root and chain keys
+    this.rootKey = null;
+    this.CKs = null; // sending chain key
+    this.CKr = null; // receiving chain key
+    this.HKs = null; // header key for sending
+    this.HKr = null; // header key for receiving
+
+    // Message numbers
+    this.Ns = 0; // messages sent in current sending chain
+    this.Nr = 0; // messages received in current receiving chain
+    this.PN = 0; // messages sent in previous sending chain
+
+    // Skipped message keys
+    this.skipKeys = new Map(); // key: dh|n -> {encKey, authKey}
   }
 
   // Load or generate identity key and create a fresh ECDH key pair
   static async create() {
     const s = new RatchetSession();
     await s._ensureIdentity();
-    s.keyPair = await crypto.subtle.generateKey(
+    s.DHs = await crypto.subtle.generateKey(
       { name: 'ECDH', namedCurve: 'P-256' },
       true,
       ['deriveBits']
     );
-    const raw = await crypto.subtle.exportKey('raw', s.keyPair.publicKey);
+    const raw = await crypto.subtle.exportKey('raw', s.DHs.publicKey);
     s.publicKey = _bufToB64(raw);
     await s._signPrekey(raw);
     return s;
   }
 
-  // Export public key as base64 string
   async exportPublicKey() {
-    const raw = await crypto.subtle.exportKey('raw', this.keyPair.publicKey);
+    const raw = await crypto.subtle.exportKey('raw', this.DHs.publicKey);
     return _bufToB64(raw);
   }
 
-  // Import peer public key from base64
   async importPeerPublicKey(b64) {
     const raw = _b64ToBuf(b64);
     return crypto.subtle.importKey(
@@ -67,7 +89,6 @@ class RatchetSession {
     );
   }
 
-  // Load identity key pair from storage or create a new one
   async _ensureIdentity() {
     const stored = localStorage.getItem('identityKeyPair');
     if (stored) {
@@ -88,7 +109,6 @@ class RatchetSession {
     }
   }
 
-  // Sign the current public key with the identity key
   async _signPrekey(rawPub) {
     const sig = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
@@ -98,28 +118,24 @@ class RatchetSession {
     this.signedPrekey = { key: this.publicKey, sig: _bufToB64(sig) };
   }
 
-  // Export identity public key
   async exportIdentityKey() {
     const raw = await crypto.subtle.exportKey('raw', this.identityKeyPair.publicKey);
     return _bufToB64(raw);
   }
 
-  // Export signed prekey (public key + signature)
   async exportSignedPrekey() {
     if (!this.signedPrekey) {
-      const raw = await crypto.subtle.exportKey('raw', this.keyPair.publicKey);
+      const raw = await crypto.subtle.exportKey('raw', this.DHs.publicKey);
       await this._signPrekey(raw);
     }
     return this.signedPrekey;
   }
 
-  // Import a peer's identity key from base64
   static async importIdentityKey(b64) {
     const raw = _b64ToBuf(b64);
     return crypto.subtle.importKey('raw', raw, { name: 'ECDSA', namedCurve: 'P-256' }, true, ['verify']);
   }
 
-  // Verify a signed prekey and return the peer's ECDH key
   static async importSignedPrekey(bundle, identityKey) {
     const keyRaw = _b64ToBuf(bundle.key);
     const sig = _b64ToBuf(bundle.sig);
@@ -139,55 +155,124 @@ class RatchetSession {
     );
   }
 
-  // After exchanging public keys, derive shared secret and set chain keys.
-  // Initiator and responder swap send/receive derivations.
+  // Initialize session after exchanging public keys
   async init(peerPublicKey, initiator = true) {
-    const peerKey = typeof peerPublicKey === 'string'
+    this.DHr = typeof peerPublicKey === 'string'
       ? await this.importPeerPublicKey(peerPublicKey)
       : peerPublicKey;
-    const shared = await crypto.subtle.deriveBits({ name: 'ECDH', public: peerKey }, this.keyPair.privateKey, 256);
-    const rootKey = new Uint8Array(shared);
+    const shared = await crypto.subtle.deriveBits({ name: 'ECDH', public: this.DHr }, this.DHs.privateKey, 256);
+    this.rootKey = new Uint8Array(shared);
     if (initiator) {
-      this.sendChainKey = await _hkdf(rootKey, 'init_send');
-      this.recvChainKey = await _hkdf(rootKey, 'init_recv');
+      this.CKs = await _hkdf(this.rootKey, 'init_CKs');
+      this.HKs = await _hkdf(this.rootKey, 'init_HKs');
+      this.CKr = await _hkdf(this.rootKey, 'init_CKr');
+      this.HKr = await _hkdf(this.rootKey, 'init_HKr');
     } else {
-      this.sendChainKey = await _hkdf(rootKey, 'init_recv');
-      this.recvChainKey = await _hkdf(rootKey, 'init_send');
+      this.CKs = await _hkdf(this.rootKey, 'init_CKr');
+      this.HKs = await _hkdf(this.rootKey, 'init_HKr');
+      this.CKr = await _hkdf(this.rootKey, 'init_CKs');
+      this.HKr = await _hkdf(this.rootKey, 'init_HKs');
     }
   }
 
-  async _nextSendKey() {
-    const mk = await _hkdf(this.sendChainKey, 'msg');
-    this.sendChainKey = await _hkdf(this.sendChainKey, 'chain');
-    return mk;
+  _mkId(dhB64, n) {
+    return `${dhB64}|${n}`;
   }
 
-  async _nextRecvKey() {
-    const mk = await _hkdf(this.recvChainKey, 'msg');
-    this.recvChainKey = await _hkdf(this.recvChainKey, 'chain');
-    return mk;
+  async _nextSendMessageKey() {
+    const mk = await _hkdf(this.CKs, 'msg');
+    this.CKs = await _hkdf(this.CKs, 'chain');
+    return {
+      encKey: await _hkdf(mk, 'enc'),
+      authKey: await _hkdf(mk, 'auth')
+    };
   }
 
-  // Encrypt a UTF-8 string, returning base64 iv and ciphertext
+  async _nextRecvMessageKey() {
+    const mk = await _hkdf(this.CKr, 'msg');
+    this.CKr = await _hkdf(this.CKr, 'chain');
+    return {
+      encKey: await _hkdf(mk, 'enc'),
+      authKey: await _hkdf(mk, 'auth')
+    };
+  }
+
+  async _skipMessageKeys(until) {
+    while (this.Nr < until) {
+      const mk = await this._nextRecvMessageKey();
+      const dhB64 = await this.exportPeerKey(this.DHr);
+      const id = this._mkId(dhB64, this.Nr);
+      this.skipKeys.set(id, mk);
+      this.Nr++;
+    }
+  }
+
+  async exportPeerKey(key) {
+    const raw = await crypto.subtle.exportKey('raw', key);
+    return _bufToB64(raw);
+  }
+
+  async _dhRatchet(newKey) {
+    this.PN = this.Ns;
+    this.Ns = 0;
+    // derive receiving chain
+    let dh = await crypto.subtle.deriveBits({ name: 'ECDH', public: newKey }, this.DHs.privateKey, 256);
+    let material = new Uint8Array([...this.rootKey, ...new Uint8Array(dh)]);
+    this.rootKey = await _hkdf(material, 'root');
+    this.CKr = await _hkdf(this.rootKey, 'recv_ck');
+    this.HKr = await _hkdf(this.rootKey, 'recv_header');
+    this.Nr = 0;
+    this.DHr = newKey;
+    // set up sending chain with new DHs
+    this.DHs = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits']);
+    const raw = await crypto.subtle.exportKey('raw', this.DHs.publicKey);
+    this.publicKey = _bufToB64(raw);
+    dh = await crypto.subtle.deriveBits({ name: 'ECDH', public: this.DHr }, this.DHs.privateKey, 256);
+    material = new Uint8Array([...this.rootKey, ...new Uint8Array(dh)]);
+    this.rootKey = await _hkdf(material, 'root');
+    this.CKs = await _hkdf(this.rootKey, 'send_ck');
+    this.HKs = await _hkdf(this.rootKey, 'send_header');
+  }
+
   async encrypt(plaintext) {
-    const keyBytes = await this._nextSendKey();
-    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
+    const dhB64 = await this.exportPublicKey();
+    const header = { dh: dhB64, pn: this.PN, n: this.Ns };
+    const headerBytes = _enc.encode(JSON.stringify(header));
+    const mk = await this._nextSendMessageKey();
+    const key = await crypto.subtle.importKey('raw', mk.encKey, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
     const iv = crypto.getRandomValues(new Uint8Array(12));
-    const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, _enc.encode(plaintext));
-    return { iv: _bufToB64(iv), data: _bufToB64(cipher) };
+    const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv, additionalData: mk.authKey }, key, _enc.encode(plaintext));
+    const tag = await _hmacSign(this.HKs, headerBytes);
+    this.Ns++;
+    return { header, tag: _bufToB64(tag), iv: _bufToB64(iv), data: _bufToB64(cipher) };
   }
 
-  // Decrypt using current receiving chain key
   async decrypt(bundle) {
-    const keyBytes = await this._nextRecvKey();
-    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
+    const headerBytes = _enc.encode(JSON.stringify(bundle.header));
+    const dhB64 = bundle.header.dh;
+    if (!this.DHr || dhB64 !== await this.exportPeerKey(this.DHr)) {
+      const key = await this.importPeerPublicKey(dhB64);
+      await this._dhRatchet(key);
+    }
+    const ok = await _hmacVerify(this.HKr, headerBytes, _b64ToBuf(bundle.tag));
+    if (!ok) throw new Error('Bad header MAC');
+    await this._skipMessageKeys(bundle.header.n);
+    const id = this._mkId(dhB64, bundle.header.n);
+    let mk;
+    if (this.skipKeys.has(id)) {
+      mk = this.skipKeys.get(id);
+      this.skipKeys.delete(id);
+    } else {
+      mk = await this._nextRecvMessageKey();
+      this.Nr++;
+    }
+    const key = await crypto.subtle.importKey('raw', mk.encKey, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
     const iv = _b64ToBuf(bundle.iv);
     const data = _b64ToBuf(bundle.data);
-    const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+    const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv, additionalData: mk.authKey }, key, data);
     return _dec.decode(plain);
   }
 }
 
 // Expose globally
 window.RatchetSession = RatchetSession;
-


### PR DESCRIPTION
## Summary
- refactor ratchet.js into a double ratchet implementation with per-message DH ratchets
- add header MACs, message numbers and skipped-key queue to handle out-of-order messages
- derive separate auth data and encryption keys while advancing send/receive chains independently

## Testing
- `node --check libs/ratchet.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a61b0e27c83319f6dfaec45e036ae