### PR TITLE
Fix session initialization check for encryption and QR features

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,7 +516,7 @@
         const resultDiv = document.getElementById('result');
         const qrCodeDiv = document.getElementById('qrcode');
         qrCodeDiv.innerHTML = '';
-        if (!window.session || !session.sendChainKey) return alert('Initialize the session first.');
+        if (!window.session || !session.CKs) return alert('Initialize the session first.');
     
         try {
           if (action === 'encryptText') {
@@ -615,7 +615,7 @@
       return;
     }
 
-    if (!window.session || !session.sendChainKey) return alert('Initialize the session first.');
+    if (!window.session || !session.CKs) return alert('Initialize the session first.');
 
     const reader = new FileReader();
     reader.onload = async function () {
@@ -660,7 +660,7 @@
         const fileInput = document.getElementById('qrInput');
         const resultDiv = document.getElementById('result');
         if (!fileInput.files[0]) return alert('Please upload a QR code image.');
-        if (!window.session || !session.sendChainKey) return alert('Initialize the session first.');
+        if (!window.session || !session.CKs) return alert('Initialize the session first.');
 
         const reader = new FileReader();
         reader.onload = async function () {


### PR DESCRIPTION
## Summary
- Ensure session initialization is validated using the correct RatchetSession chain key before performing actions
- Applies check across text encryption, image encryption, and QR decoding handlers

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Beam/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a683117248331954142372c276f2f