### PR TITLE
Encode hash in shared URLs and warn on long fragments

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
   
   <script>
     const MAX_OUTPUT_LENGTH = 1000;
+    const URL_HASH_WARNING_LENGTH = 2048; // ~2KB typical URL length limit
     const enc = new TextEncoder();
     const MAX_CONTACT_IMAGE_SIZE = 100 * 1024; // 100KB
 
@@ -509,7 +510,7 @@
       document.getElementById('exportPubKey').addEventListener('click', exportPublicKey);
       
       // Check for code in URL hash and set decryption view if present
-      const code = window.location.hash.substring(1);
+      const code = decodeURIComponent(window.location.hash.substring(1));
       if (code) {
         document.getElementById('action').value = 'decrypt';
         document.getElementById('message').value = code;
@@ -738,9 +739,13 @@
           downloadLink.click();
           return;
         }
-    
+
         const url = new URL(window.location.href);
-        url.hash = cleaned;
+        const encodedHash = encodeURIComponent(cleaned);
+        if (encodedHash.length > URL_HASH_WARNING_LENGTH) {
+          alert('Warning: URL hash exceeds ~2KB and may not be supported by all browsers.');
+        }
+        url.hash = encodedHash;
     
         const shareData = {
           title: 'Encrypted Message',


### PR DESCRIPTION
## Summary
- Encode shared URL hash fragments to avoid malformed links
- Decode URL hash on load to restore original encrypted content
- Warn users when URL hash exceeds typical 2KB size limit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a763015088331b62cfe169aa71332